### PR TITLE
Fix: metatag regexp search in bytes failed

### DIFF
--- a/domcheck/strategies.py
+++ b/domcheck/strategies.py
@@ -74,7 +74,7 @@ def check_meta_tag(domain, prefix, code):
             res = urlopen(req, timeout=2)
             if res.code == 200:
                 # Expect the </head> to be found in the first 100k of the page
-                content = res.read(100000)
+                content = str(res.read(100000))
                 res.close()
                 return search_meta_tag(content, prefix, code)
             else:


### PR DESCRIPTION
Workaround for problem with metatag searching in content as bytes (Python 3)